### PR TITLE
Added in Basic Multi-tap Detection/Support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
 EE_BIN = mcFormatter.elf
+EE_BIN_PACKED = mcF-packed.elf
 EE_OBJS = main.o
 EE_LDFLAGS = -L$(PS2SDK)/sbv/lib 
-EE_LIBS = -lpad -ldebug -lmc -lc
+EE_LIBS = -lpadx -lmtap -ldebug -lmc -lc
+
 all: $(EE_BIN)
+
+# Un Comment to Enable Compression of the ELF. you will need ps2packer in the project dir
+# all: $(EE_BIN)
+	# ps2_packer/ps2_packer -p zlib $(EE_BIN) $(EE_BIN_PACKED)
+	# cp -f --remove-destination $(EE_BIN_PACKED) $(EE_BIN_DIR)/$(EE_BIN)
+
 
 clean:
 	rm -f *.elf *.o *.a
 
+
+	
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # PS2-Memory-Card-Formatter
 PS2 Homebrew Utility that will format both Memory Card Slot 1 and 2
+
+
+This Program Utilizes The PS2DEV sdk https://github.com/ps2dev/ps2sdk

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 PS2 Homebrew Utility that will format both Memory Card Slot 1 and 2
 
 
-This Program Utilizes The PS2DEV sdk https://github.com/ps2dev/ps2sdk
+This Program Was Built with The PS2DEV sdk https://github.com/ps2dev/ps2sdk


### PR DESCRIPTION
The App Is Now Capable of Detecting if a Multi-tap is inserted in either port 1 or port 2.
(It Only Formats Cards Connected to Slot A of a Multi-tap)

Now Using X-Modules (Warning: This Also Breaks Compatibility with Some Consoles)
X-Modules Are Required to use the Multitap - See https://github.com/ps2dev/ps2sdk/tree/master/ee/rpc/multitap

Eliminated the Type_MC definition and Left the Type_XMC Definition as we are using X-Modules 
Also Eliminated the Other Call Related to It.
(Thanks SP193 For The Information)

fixed the spelling of the initialize() function

Changed the Displayed Application Name to Mass Format Utility.

Added In Information about the Multi-Tap in the comments of the Code for Future Reference that could be useful to other developers.